### PR TITLE
Fix inline doc for Rakefile content

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,6 +35,7 @@ Quarto depends on several external programs which you will need to install befor
 
 1. Install the gem (`gem install quarto`)
 2. Create a `Rakefile` in your book project root, with the following content:
+    
     ```ruby
     require 'quarto/tasks'
     ```


### PR DESCRIPTION
The previous docs would set the `require 'quarto/tasks'` to be inline but because the code was set to be displayed as `ruby` code and no newline was present before the code block, the `ruby` processing command was displayed as text.

This changes the docs from saying `ruby require 'quarto/tasks'` to `require 'quarto/tasks'`

As a result, the display code is no longer inline, but it is syntax highlighted.
