### PR TITLE
Fix rake dependency in gemspec

### DIFF
--- a/quarto.gemspec
+++ b/quarto.gemspec
@@ -18,7 +18,8 @@ Gem::Specification.new do |spec|
   spec.test_files    = spec.files.grep(%r{^(test|spec|features)/})
   spec.require_paths = ["lib"]
 
-  spec.add_dependency "rake", "~> 10.0"
+  spec.add_runtime_dependency 'rake', '~> 10.0', '~> 10.0'
+
   spec.add_dependency "nokogiri", "~> 1.6"
   spec.add_dependency "fattr", "~> 2.2"
   spec.add_dependency "sass",  "~> 3.2"
@@ -29,7 +30,6 @@ Gem::Specification.new do |spec|
   spec.add_dependency "naught"
 
   spec.add_development_dependency "bundler", "~> 1.3"
-  spec.add_development_dependency "rake", "~> 10.0"
   spec.add_development_dependency "rspec", "~> 2.14"
   spec.add_development_dependency "rspec-given", "~> 3.1"
   spec.add_development_dependency "test-construct", "~> 1.2"


### PR DESCRIPTION
Error was (in ruby 2.1.0):
    quarto at /Users/brad/dev/avdi/quarto did not have a valid gemspec.
    This prevents bundler from installing bins or native extensions, but
    that may not affect its functionality.
    The validation message from Rubygems was:
      duplicate dependency on rake (~> 10.0, development), (~> 10.0) use:
          add_runtime_dependency 'rake', '~> 10.0', '~> 10.0'
