### PR TITLE
Fixes typo in the README docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -166,7 +166,7 @@ By default Quarto seeks out source files with extensions it knows about. Alterna
 
 ```ruby
 Quarto.configure do |config|
-  config.source_files = [
+  config.source_files << [
     "ch1.md",
     "subdir/ch3.org"
   ]


### PR DESCRIPTION
The `config` object doesn't have a `source_files=` method specified, but using the `<<` to add an array of files seems to work.
